### PR TITLE
Use glos.convert, pass csv delimiter and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ https://www.ling.upenn.edu/~kurisuto/germanic/oe_bosworthtoller_about.html
 ## Instructions
 
 ```
-git clone git@github.com:loco-lab/pyglossary.git
+git clone git@github.com:ilius/pyglossary.git
 cd pyglossary
-git checkout at_delim
 pip install .
 ```
 

--- a/csv_to_apple.py
+++ b/csv_to_apple.py
@@ -1,7 +1,14 @@
-import pyglossary
+from pyglossary import Glossary
 import sys
 
+Glossary.init()
 
-my_dict = pyglossary.Glossary()
-my_dict.read(sys.argv[1], progressbar=False)
-my_dict.write(sys.argv[2], 'AppleDict')
+glos = Glossary()
+glos.convert(
+    inputFilename=sys.argv[1],
+    outputFilename=sys.argv[2],
+    outputFormat='AppleDict',
+    readOptions={
+        'delimiter': '@',
+    },
+)


### PR DESCRIPTION
- Use `convert` instead of `read` and `write` so that it doesn't load it into memory.
- Pass `delimiter` as read-option so that you don't have to maintain a fork (https://github.com/loco-lab/pyglossary/commit/dead2ff8a8ba50907effae7bcc29d372ce7932a1)
- Update instructions to use the latest upstream code.